### PR TITLE
Multiple asserts in single test file naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Next
 
+- Add index to the snapshot to avoid name clash on multiple asserts in one test (#10, kudos to @komkovla)
 - Add `displayScale` parameter to public assert functions (#9, kudos to @olejnjak)
 - Fixes bug: Snapshot for one device doesn't respect scrollViewMultiplier (#7) (#8, kudos to @komkovla)
 

--- a/Sources/AckeeSnapshots/Counter.swift
+++ b/Sources/AckeeSnapshots/Counter.swift
@@ -1,0 +1,41 @@
+import Foundation
+import XCTest
+
+// Used for per-test assert snapshot counting
+final class Counter {
+    private var counts: [String: Int] = [:]
+    private let lock = NSLock()
+
+    func next(for key: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        counts[key, default: 0] += 1
+        return counts[key]!
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        counts.removeAll()
+    }
+}
+
+/// Reset timer between tests
+class CleanCounterBetweenTestCases: NSObject, XCTestObservation {
+    private static var registered = false
+
+    static func registerIfNeeded() {
+        guard !registered else { return }
+        defer { registered = true }
+        Task {@MainActor in
+            XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
+        }
+    }
+
+    func testCaseDidFinish(_ testCase: XCTestCase) {
+        snapshotCounter.reset()
+    }
+}
+
+// Singleton instance of the counter, like in Swift-snapshot-testing
+let snapshotCounter = Counter()

--- a/Sources/AckeeSnapshots/SnapshotTest.swift
+++ b/Sources/AckeeSnapshots/SnapshotTest.swift
@@ -258,12 +258,25 @@ public struct SnapshotTest {
         assertSnapshot(
             of: view,
             as: wait > 0 ? .wait(for: wait, on: strategy): strategy,
-            named: [deviceName, name].joined(separator: "_"),
+            named: getSnapshotName(file: file, testName: testName, deviceName: deviceName, name: name),
             record: record ?? self.record,
             file: file,
             testName: testName,
             line: line
         )
+    }
+
+    private func getSnapshotName(
+        file: StaticString,
+        testName: String,
+        deviceName: String,
+        name: String
+    ) -> String {
+        let filePath = "\(file)"
+        let keyBaseParts: [String] = [filePath, testName, deviceName, name].compactMap { $0.isEmpty ? nil : $0 }
+        let counterKey = keyBaseParts.joined(separator: "_")
+        let snapshotIndex = snapshotCounter.next(for: counterKey)
+        return ([deviceName, name, "\(snapshotIndex)"].compactMap { $0.isEmpty ? nil : $0 }.joined(separator: "_"))
     }
 
     private func assertDynamicTypes<View: SwiftUI.View>(


### PR DESCRIPTION
## Summary 

- 🐛 Fix having multiple asserts in single test resulted in name clash and test fail.
- ✨ Implement counter - singleton for getting count of the snapshot on specific test-device-size combination
- ❗ Breaking Change - naming of snapshots newly would have `_1` suffix so already existing snapshots would need to be renamed

Resolves bug https://github.com/AckeeCZ/ackee-ios-snapshots/issues/6

## Author checklist
- [x] updated [changelog](CHANGELOG.md) under _Next_ section