### PR TITLE
🐛 Constrain color scheme in device tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 
-on: 
+on:
   workflow_call:
-  push: 
+  push:
     branches:
       - main
   pull_request:
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.4.app
+  DEVELOPER_DIR: /Applications/Xcode_26.0.app
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Next
 
+- Fix colorScheme is not applied on size and component snapshots (#13, kudos to @komkovla)
 - Fix counter not being reset between test cases (#12, kudos to @komkovla)
 
 ## 0.4.0

--- a/Sources/AckeeSnapshots/SnapshotTest+SwiftUI.swift
+++ b/Sources/AckeeSnapshots/SnapshotTest+SwiftUI.swift
@@ -284,6 +284,7 @@ extension SnapshotTest {
                 layout: layout,
                 traits: .init(traitsFrom: [
                     .init(preferredContentSizeCategory: contentSize.uiContentSizeCategory),
+                    .init(userInterfaceStyle: colorSchemes.first?.uiUserInterfaceStyle ?? .light),
                     (scaleParam ?? displayScale).map { .init(displayScale: $0) },
                 ].compactMap { $0 })
             )
@@ -362,7 +363,12 @@ extension SnapshotTest {
         let strategy = Snapshotting<FixedDynamicView, UIImage>.image(
             drawHierarchyInKeyWindow: false,
             layout: .sizeThatFits,
-            traits: (scaleParam ?? displayScale).map { .init(displayScale: $0) } ?? .init()
+            traits: .init(
+                traitsFrom: [
+                    (scaleParam ?? displayScale).map { .init(displayScale: $0) },
+                    .init(userInterfaceStyle: colorSchemes.first?.uiUserInterfaceStyle ?? .light)
+                ].compactMap { $0 }
+            )
         )
 
         sizes.forEach { contentSize, name in

--- a/Sources/AckeeSnapshots/SnapshotTest+UIView.swift
+++ b/Sources/AckeeSnapshots/SnapshotTest+UIView.swift
@@ -117,6 +117,7 @@ extension SnapshotTest {
                 traits: .init(traitsFrom: [
                     device.config.traits,
                     .init(preferredContentSizeCategory: contentSize.uiContentSizeCategory),
+                    .init(userInterfaceStyle: colorSchemes.first?.uiUserInterfaceStyle ?? .light),
                     (displayScale ?? self.displayScale).map { .init(displayScale: $0) },
                 ].compactMap { $0 })
             )
@@ -178,6 +179,7 @@ extension SnapshotTest {
                 size: size,
                 traits: .init(traitsFrom: [
                     .init(preferredContentSizeCategory: contentSize.uiContentSizeCategory),
+                    .init(userInterfaceStyle: colorSchemes.first?.uiUserInterfaceStyle ?? .light),
                     (displayScale ?? self.displayScale).map { .init(displayScale: $0) },
                 ].compactMap { $0 })
             )

--- a/Sources/AckeeSnapshots/SnapshotTest+UIViewController.swift
+++ b/Sources/AckeeSnapshots/SnapshotTest+UIViewController.swift
@@ -115,6 +115,7 @@ extension SnapshotTest {
                 perceptualPrecision: Float(precision),
                 traits: .init(traitsFrom: [
                     .init(preferredContentSizeCategory: contentSize.uiContentSizeCategory),
+                    .init(userInterfaceStyle: colorSchemes.first?.uiUserInterfaceStyle ?? .light),
                     (displayScale ?? self.displayScale).map { .init(displayScale: $0) },
                 ].compactMap { $0 })
             )


### PR DESCRIPTION
## Summary 

- When `SnapshotTest` defined with one color scheme library would not respect it and snapshot `.light` colorScheme on devices. 
- Constrain color scheme to first defined if available

## Author checklist
- [x] updated [changelog](CHANGELOG.md) under _Next_ section